### PR TITLE
Add option for single or list of flows. 

### DIFF
--- a/src/commands/flow/scan.ts
+++ b/src/commands/flow/scan.ts
@@ -39,6 +39,11 @@ export default class scan extends SfdxCommand {
       char: 'd',
       description: messages.getMessage('directoryToScan'),
       required: false
+    }),
+    sourcepath: flags.filepath({
+      char: 'p',
+      description: 'comma-separated list of source file paths to deploy',
+      required: false
     })
   };
 
@@ -72,9 +77,14 @@ export default class scan extends SfdxCommand {
     }
 
     let flowFiles;
+    if (this.flags.directory && this.flags.sourcepath){
+        throw new SfdxError('You can only specify one of either directory or sourcepath, not both.');
+    }
     if(this.flags.directory){
       flowFiles = FindFlows(this.flags.directory);
-    } else {
+    } else if(this.flags.sourcepath){
+      flowFiles = this.flags.sourcepath.split(',').filter( f => fs.existsSync(f));
+    }else {
       flowFiles = FindFlows(this.rootPath);
     }
     const pathToIgnoreFile = path.join(this.rootPath, '.flowscanignore');

--- a/src/commands/flow/scan.ts
+++ b/src/commands/flow/scan.ts
@@ -42,7 +42,7 @@ export default class scan extends SfdxCommand {
     }),
     sourcepath: flags.filepath({
       char: 'p',
-      description: 'comma-separated list of source file paths to deploy',
+      description: 'comma-separated list of source flow paths to scan',
       required: false
     })
   };


### PR DESCRIPTION
add option as sorucepath (or -p)  to scan single or a list of flows (comma separated).

Example 
![image](https://user-images.githubusercontent.com/20630942/233904799-2c5b5349-02d5-445a-b4a8-4dca98ef5e3d.png)
