### PR TITLE
Use cosmiconfig + code refactoring

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
           node-version: 16
           registry-url: "https://registry.npmjs.org"
           # Defaults to the user or organization that owns the workflow file
-          scope: "nvuillam"
+          scope: "rubenhalman"
       - run: yarn
       - run: yarn prepack
       - run: yarn test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,38 @@
+---
+#
+# Documentation:
+# https://help.github.com/en/articles/workflow-syntax-for-github-actions
+#
+
+#######################################
+# Start the job on all push to master #
+#######################################
+name: "Test"
+on:
+  push: # Comment this line to trigger action only on pull-requests (not recommended if you don't pay for GH Actions)
+  pull_request:
+    branches: [master, main]
+
+###############
+# Set the Job #
+###############
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    if: (github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository) && !contains(github.event.head_commit.message, 'skip deploy')
+    steps:
+      - uses: actions/checkout@v3
+      # Setup .npmrc file to publish to npm
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          registry-url: "https://registry.npmjs.org"
+          # Defaults to the user or organization that owns the workflow file
+          scope: "nvuillam"
+      - run: yarn
+      - run: yarn prepack
+      - run: yarn test
+#      - name: Submitting code coverage to codecov
+#        run: |
+#          ./node_modules/.bin/nyc report --reporter text-lcov > coverage.lcov
+#          curl -s https://codecov.io/bash | bash

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 *-error.log
 .DS_Store
 /.nyc_output
-/.vscode
 /dist
 /lib
 /node_modules

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,50 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "attach",
+      "name": "Attach to Remote",
+      "address": "127.0.0.1",
+      "port": 9229,
+      "localRoot": "${workspaceFolder}",
+      "remoteRoot": "${workspaceFolder}",
+      "stopOnEntry": false,
+      "skipFiles": ["<node_internals>/**"]
+    },
+    {
+      "name": "Run All Tests",
+      "type": "node",
+      "request": "launch",
+      "protocol": "inspector",
+      "program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
+      "args": ["--inspect", "--no-timeouts", "--colors", "test/**/*.test.ts"],
+      "env": {
+        "NODE_ENV": "development",
+        "SFDX_ENV": "development"
+      },
+      "sourceMaps": true,
+      "smartStep": true,
+      "internalConsoleOptions": "openOnSessionStart",
+      "preLaunchTask": "Compile"
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Run Current Test",
+      "program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
+      "args": ["--inspect", "--no-timeouts", "--colors", "${file}"],
+      "env": {
+        "NODE_ENV": "development",
+        "SFDX_ENV": "development"
+      },
+      "sourceMaps": true,
+      "smartStep": true,
+      "internalConsoleOptions": "openOnSessionStart",
+      "preLaunchTask": "Compile"
+    }
+  ]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased] (beta, main branch content)
+
+- Use [cosmiconfig](https://github.com/cosmiconfig/cosmiconfig) to load configuration
+- Add CHANGELOG.md file
+- Code refactorization
+  - let <=> const
+  - Split main method into smaller methods
+  - use fs-extra instead of sf plugin fs
+
+<!-- Example : ## [1.0.0] - 2020-11-17 -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,5 +12,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
   - let <=> const
   - Split main method into smaller methods
   - use fs-extra instead of sf plugin fs
+- Upgrade dependencies
 
 <!-- Example : ## [1.0.0] - 2020-11-17 -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,5 +16,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
   - use fs-extra instead of sf plugin fs
   - Remove tslint (deprecated), replaced by eslint
   - Upgrade dependencies
+  - Add VsCode local debugging configuration
 
 <!-- Example : ## [1.0.0] - 2020-11-17 -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased] (beta, main branch content)
 
 - Use [cosmiconfig](https://github.com/cosmiconfig/cosmiconfig) to load configuration
+- Add a **--retrieve** argument in case user wants to retrieve flows from org before scanning
+- Add a testing GitHub action Workflow 
 - Add CHANGELOG.md file
 - Code refactorization
   - let <=> const
   - Split main method into smaller methods
   - use fs-extra instead of sf plugin fs
-- Upgrade dependencies
+  - Remove tslint (deprecated), replaced by eslint
+  - Upgrade dependencies
 
 <!-- Example : ## [1.0.0] - 2020-11-17 -->

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "mocha": "^5",
     "nyc": "^14",
     "prettier": "^2.3.2",
-    "ts-node": "^8",
+    "ts-node": "10.7.0",
     "tslint": "^5",
     "typescript": "^4.3.5"
   },

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "@salesforce/command": "^2",
     "@salesforce/core": "^2",
     "chalk": "^4.1.2",
+    "cosmiconfig": "^8.1.3",
+    "fs-extra": "^11.1.1",
     "glob": "^7.1.7",
     "lightning-flow-scanner-core": "^1.0.1",
     "tslib": "^1",

--- a/package.json
+++ b/package.json
@@ -69,9 +69,8 @@
   },
   "repository": "https://github.com/Force-Config-Control/lightning-flow-scanner-sfdx.git",
   "scripts": {
-    "lint": "tslint --project . --config tslint.json --format stylish",
+    "lint": "eslint",
     "postpack": "rm -f oclif.manifest.json",
-    "posttest": "tslint -p test -t stylish",
     "prepack": "rm -rf lib && tsc -b && oclif-dev manifest && oclif-dev readme",
     "prettier": "prettier --write '**/*.{js,json,md,ts,yaml,yml}'",
     "test": "nyc --extension .ts mocha --forbid-only \"test/**/*.test.ts\"",

--- a/src/commands/flow/scan.ts
+++ b/src/commands/flow/scan.ts
@@ -2,7 +2,7 @@ import { SfdxCommand, flags } from '@salesforce/command';
 import { Messages, SfdxError, SfdxProject } from '@salesforce/core';
 import { AnyJson } from '@salesforce/ts-types';
 import * as core from 'lightning-flow-scanner-core/out';
-import * as fs from 'fs-extra';
+import * as fs from 'fs-extra'; 
 import { Flow } from 'lightning-flow-scanner-core/out/main/models/Flow';
 import { ScanResult } from 'lightning-flow-scanner-core/out/main/models/ScanResult';
 import { FindFlows } from '../../libs/FindFlows';

--- a/src/commands/flow/scan.ts
+++ b/src/commands/flow/scan.ts
@@ -151,12 +151,12 @@ export default class scan extends SfdxCommand {
       `config/.${moduleName}.yaml`,
       `config/.${moduleName}.yml`,
       `.flowscanignore`];
-    const explorer = await cosmiconfig("flow-scanner", {
+    const explorer = cosmiconfig(moduleName, {
       searchPlaces,
     });
     if (forcedConfigFile) {
       // Forced config file name
-      this.userConfig = explorer.load(forcedConfigFile);
+      this.userConfig = await explorer.load(forcedConfigFile);
     }
     else {
       // Let cosmiconfig look for a config file

--- a/src/commands/flow/scan.ts
+++ b/src/commands/flow/scan.ts
@@ -156,7 +156,8 @@ export default class scan extends SfdxCommand {
     });
     if (forcedConfigFile) {
       // Forced config file name
-      this.userConfig = await explorer.load(forcedConfigFile);
+      const explorerLoadRes = await explorer.load(forcedConfigFile);
+      this.userConfig = explorerLoadRes?.config ?? {}
     }
     else {
       // Let cosmiconfig look for a config file

--- a/src/commands/flow/scan.ts
+++ b/src/commands/flow/scan.ts
@@ -1,18 +1,19 @@
-import {SfdxCommand, flags} from '@salesforce/command';
-import {fs, Messages, SfdxError, SfdxProject} from '@salesforce/core';
-import {AnyJson} from '@salesforce/ts-types';
+import { SfdxCommand, flags } from '@salesforce/command';
+import { Messages, SfdxError, SfdxProject } from '@salesforce/core';
+import { AnyJson } from '@salesforce/ts-types';
 import * as core from 'lightning-flow-scanner-core/out';
-import {Flow} from 'lightning-flow-scanner-core/out/main/models/Flow';
-import {ScanResult} from 'lightning-flow-scanner-core/out/main/models/ScanResult';
-import * as path from 'path';
-import {FindFlows} from '../../libs/FindFlows';
-import {ParseFlows} from '../../libs/ParseFlows';
-import {Violation} from '../../models/Violation';
-import {ScannerOptions} from 'lightning-flow-scanner-core/out/main/models/ScannerOptions';
-import {Override} from "lightning-flow-scanner-core/out/main/models/Override";
-import {FlowScanOverrides} from "lightning-flow-scanner-core/out/main/models/FlowScanOverrides";
+import * as fs from 'fs-extra';
+import { Flow } from 'lightning-flow-scanner-core/out/main/models/Flow';
+import { ScanResult } from 'lightning-flow-scanner-core/out/main/models/ScanResult';
+import { FindFlows } from '../../libs/FindFlows';
+import { ParseFlows } from '../../libs/ParseFlows';
+import { Violation } from '../../models/Violation';
+import { ScannerOptions } from 'lightning-flow-scanner-core/out/main/models/ScannerOptions';
+import { Override } from "lightning-flow-scanner-core/out/main/models/Override";
+import { FlowScanOverrides } from "lightning-flow-scanner-core/out/main/models/FlowScanOverrides";
 import * as chalk from "chalk";
 import { exec } from 'child_process';
+import { cosmiconfig } from 'cosmiconfig';
 
 Messages.importMessagesDirectory(__dirname);
 
@@ -28,6 +29,8 @@ export default class scan extends SfdxCommand {
   protected static supportsUsername = true;
 
   public rootPath;
+  protected userConfig;
+  protected scannerOptions: ScannerOptions;
 
   protected static flagsConfig = {
     help: flags.help({ char: 'h' }),
@@ -40,6 +43,16 @@ export default class scan extends SfdxCommand {
       description: messages.getMessage('directoryToScan'),
       required: false
     }),
+    config: flags.filepath({
+      char: 'c',
+      description: "Path to configuration file",
+      required: false
+    }),
+    retrieve: flags.boolean({
+      char: 'r',
+      description: "Force retrieve Flows from org at the start of the command",
+      default: false
+    }),
     sourcepath: flags.filepath({
       char: 'p',
       description: 'comma-separated list of source flow paths to scan',
@@ -50,56 +63,37 @@ export default class scan extends SfdxCommand {
   public async run(): Promise<AnyJson> {
     this.rootPath = await SfdxProject.resolveProjectPath();
 
-    // username provided
-    let errored = false;
-    if(this.flags.targetusername){
-      this.ux.startSpinner(chalk.yellowBright('Retrieving Metadata...'));
-      const retrieveCommand = `sfdx force:source:retrieve -m Flow -u"${
-        this.flags.targetusername
-      }"`;
-      // -r ./${tmpDir} -w 30 --json
-      try {
-        await exec(retrieveCommand, {
-          maxBuffer: 1000000 * 1024
-        });
-      } catch (exception) {
-        errored = true;
-        this.ux.errorJson(exception);
-        this.ux.stopSpinner(chalk.redBright('Retrieve Operation Failed.'));
-      }
-    }
-    if(errored){
-      throw new SfdxError(messages.getMessage('errorRetrievingMetadata'), '', [], 1);
-    } else {
-      this.ux.stopSpinner(
-        chalk.greenBright('Retrieve Completed ✔.')
-      );
+    // Load user options
+    await this.loadScannerOptions(this.flags.config);
+
+    // Retrieve flows from org if necessary
+    if (this.flags.retrieve) {
+      await this.retrieveFlowsFromOrg();
     }
 
+    // List flows that will be scanned
     let flowFiles;
-    if (this.flags.directory && this.flags.sourcepath){
-        throw new SfdxError('You can only specify one of either directory or sourcepath, not both.');
+    if (this.flags.directory && this.flags.sourcepath) {
+      throw new SfdxError('You can only specify one of either directory or sourcepath, not both.');
     }
-    if(this.flags.directory){
+    if (this.flags.directory) {
       flowFiles = FindFlows(this.flags.directory);
-    } else if(this.flags.sourcepath){
-      flowFiles = this.flags.sourcepath.split(',').filter( f => fs.existsSync(f));
-    }else {
+    } else if (this.flags.sourcepath) {
+      flowFiles = this.flags.sourcepath.split(',').filter(f => fs.existsSync(f));
+    } else {
       flowFiles = FindFlows(this.rootPath);
     }
-    const pathToIgnoreFile = path.join(this.rootPath, '.flowscanignore');
-    let ruleOptions;
-    if (pathToIgnoreFile) {
-      ruleOptions = this.createScannerOptions(pathToIgnoreFile);
-    }
+
+    // Perform scan
     const parsedFlows: Flow[] = await ParseFlows(flowFiles);
     let scanResults: ScanResult[];
-    if (ruleOptions) {
-      scanResults = core.scan(parsedFlows, ruleOptions);
+    if (this.scannerOptions && Object.keys(this.scannerOptions).length > 0) {
+      scanResults = core.scan(parsedFlows, this.scannerOptions);
     } else {
       scanResults = core.scan(parsedFlows);
     }
 
+    // Build result
     const lintResults: Violation[] = [];
     for (const scanResult of scanResults) {
       for (const ruleResult of scanResult.ruleResults) {
@@ -126,14 +120,14 @@ export default class scan extends SfdxCommand {
         }
       }
     }
-    let totalFlows = scanResults.length;
-    let results = lintResults.length;
-    const summary = {totalFlows, results};
+    const totalFlows = scanResults.length;
+    const results = lintResults.length;
+    const summary = { totalFlows, results };
     const errors = lintResults;
-    this.ux.logJson(results > 0 ? {summary, errors} : {summary});
+    this.ux.logJson(results > 0 ? { summary, errors } : { summary });
 
     if (!this.flags.silent && lintResults.length > 0) {
-      let labels: string[] = [];
+      const labels: string[] = [];
       for (const lintResult of lintResults) {
         if (!labels.includes(lintResult.flowName)) {
           labels.push(lintResult.flowName);
@@ -145,27 +139,70 @@ export default class scan extends SfdxCommand {
     return 0;
   }
 
-  private createScannerOptions(pathToIgnoreFile): ScannerOptions {
+  // lightning flow scanner can be customized using a local config file .flow-scanner.yml
+  private async loadScannerOptions(forcedConfigFile: string): Promise<void> {
+    // Read config from file
+    const moduleName = "flow-scanner";
+    const searchPlaces = [
+      "package.json",
+      `.${moduleName}.yaml`,
+      `.${moduleName}.yml`,
+      `.${moduleName}.json`,
+      `config/.${moduleName}.yaml`,
+      `config/.${moduleName}.yml`,
+      `.flowscanignore`];
+    const explorer = await cosmiconfig("flow-scanner", {
+      searchPlaces,
+    });
+    if (forcedConfigFile) {
+      // Forced config file name
+      this.userConfig = explorer.load(forcedConfigFile);
+    }
+    else {
+      // Let cosmiconfig look for a config file
+      const explorerSearchRes = await explorer.search();
+      this.userConfig = explorerSearchRes.config ?? {}
+    }
 
-    try {
-      const ignoreFile = fs.readJsonSync(pathToIgnoreFile);
-      let rules = ignoreFile['activeRules'];
-      let flowScanOverrides = [];
-      if (ignoreFile['overrides']) {
-        for (let override of ignoreFile['overrides']) {
-          let overrides = [];
-          if (override['results']) {
-            for (let result of override['results']) {
-              overrides.push(new Override(result.ruleName, result.result));
-            }
-            flowScanOverrides.push(new FlowScanOverrides(override.flowName, overrides));
+    // Build ScannerOptions from config file values
+    const rules = this.userConfig['activeRules'];
+    const flowScanOverrides = [];
+    if (this.userConfig['overrides']) {
+      for (const override of this.userConfig['overrides']) {
+        const overrides = [];
+        if (override['results']) {
+          for (const result of override['results']) {
+            overrides.push(new Override(result.ruleName, result.result));
           }
+          flowScanOverrides.push(new FlowScanOverrides(override.flowName, overrides));
         }
       }
-      return new ScannerOptions(rules, flowScanOverrides);
-    } catch (e) {
-
     }
+    this.scannerOptions = new ScannerOptions(rules, flowScanOverrides);
   }
 
+  // Use sfdx to retrieve flows from remote org
+  private async retrieveFlowsFromOrg() {
+    let errored = false;
+    this.ux.startSpinner(chalk.yellowBright('Retrieving Metadata...'));
+    const retrieveCommand = `sfdx force:source:retrieve -m Flow -u "${this.flags.targetusername
+      }"`;
+    // -r ./${tmpDir} -w 30 --json
+    try {
+      await exec(retrieveCommand, {
+        maxBuffer: 1000000 * 1024
+      });
+    } catch (exception) {
+      errored = true;
+      this.ux.errorJson(exception);
+      this.ux.stopSpinner(chalk.redBright('Retrieve Operation Failed.'));
+    }
+    if (errored) {
+      throw new SfdxError(messages.getMessage('errorRetrievingMetadata'), '', [], 1);
+    } else {
+      this.ux.stopSpinner(
+        chalk.greenBright('Retrieve Completed ✔.')
+      );
+    }
+  }
 }

--- a/src/commands/flow/scan.ts
+++ b/src/commands/flow/scan.ts
@@ -161,7 +161,7 @@ export default class scan extends SfdxCommand {
     else {
       // Let cosmiconfig look for a config file
       const explorerSearchRes = await explorer.search();
-      this.userConfig = explorerSearchRes.config ?? {}
+      this.userConfig = explorerSearchRes?.config ?? {}
     }
 
     // Build ScannerOptions from config file values

--- a/test/commands/flow/scan.test.ts
+++ b/test/commands/flow/scan.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from '@salesforce/command/lib/test';
 import { ensureJsonMap, ensureString } from '@salesforce/ts-types';
 
-describe('hello:org', () => {
+describe('flow:scan', () => {
   test
     .withOrg({ username: 'test@org.com' }, true)
     .withConnectionRequest(request => {
@@ -12,8 +12,8 @@ describe('hello:org', () => {
       return Promise.resolve({ records: [] });
     })
     .stdout()
-    .command(['hello:org', '--targetusername', 'test@org.com'])
-    .it('runs hello:org --targetusername test@org.com', ctx => {
-      expect(ctx.stdout).to.contain('Hello world! This is org: Super Awesome Org and I will be around until Tue Mar 20 2018!');
+    .command(['flow:scan'])
+    .it('runs flow:orscang', ctx => {
+      expect(ctx.stdout).to.contain('');
     });
 });

--- a/test/commands/flow/scan.test.ts
+++ b/test/commands/flow/scan.test.ts
@@ -14,6 +14,6 @@ describe('flow:scan', () => {
     .stdout()
     .command(['flow:scan'])
     .it('runs flow:orscang', ctx => {
-      expect(ctx.stdout).to.contain('');
+      expect(ctx.stdout).to.contain('"summary"');
     });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,12 +1,18 @@
 {
-  "extends": "./node_modules/@salesforce/dev-config/tsconfig",
   "compilerOptions": {
+    "moduleResolution": "node",
+    "module": "commonjs",
+    "target": "es2019",
+    "lib": ["es2019"],
+    "alwaysStrict": true,
+    "noUnusedLocals": true,
+    "sourceMap": true,
     "declaration": true,
     "outDir": "./lib",
     "importHelpers": true,
-    "rootDir": "./src"
+    "resolveJsonModule": true,
+    "types": ["node", "mocha"],
+    "skipLibCheck": true
   },
-  "include": [
-    "./src/**/*"
-  ]
+  "include": ["./src/**/*"]
 }

--- a/tslint.json
+++ b/tslint.json
@@ -1,4 +1,0 @@
-{
-    "extends": "@salesforce/dev-config/tslint"
-  }
-  

--- a/yarn.lock
+++ b/yarn.lock
@@ -815,10 +815,6 @@ buffer-equal-constant-time@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz#f8e71132f7ffe6e01a5c9697a4c6f3e48d5cc819"
 
-buffer-from@^1.0.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
-
 buffer@^5.5.0:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.7.1.tgz#ba62e7c13133053582197160851a8f648e99eed0"
@@ -3652,13 +3648,6 @@ source-map-resolve@^0.5.0:
     source-map-url "^0.4.0"
     urix "^0.1.0"
 
-source-map-support@^0.5.17:
-  version "0.5.19"
-  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.19.tgz#a98b62f86dcaf4f67399648c085291ab9e8fed61"
-  dependencies:
-    buffer-from "^1.0.0"
-    source-map "^0.6.0"
-
 source-map-url@^0.4.0:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/source-map-url/-/source-map-url-0.4.1.tgz#0af66605a745a5a2f91cf1bbf8a7afbc283dec56"
@@ -3667,7 +3656,7 @@ source-map@^0.5.0, source-map@^0.5.6:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
 
-source-map@^0.6.0, source-map@^0.6.1:
+source-map@^0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
 
@@ -3974,6 +3963,25 @@ treeify@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/treeify/-/treeify-1.1.0.tgz#4e31c6a463accd0943879f30667c4fdaff411bb8"
 
+ts-node@10.7.0:
+  version "10.7.0"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-10.7.0.tgz#35d503d0fab3e2baa672a0e94f4b40653c2463f5"
+  integrity sha512-TbIGS4xgJoX2i3do417KSaep1uRAW/Lu+WAL2doDHC0D6ummjirVOXU5/7aiZotbQ5p1Zp9tP7U6cYhA0O7M8A==
+  dependencies:
+    "@cspotcode/source-map-support" "0.7.0"
+    "@tsconfig/node10" "^1.0.7"
+    "@tsconfig/node12" "^1.0.7"
+    "@tsconfig/node14" "^1.0.0"
+    "@tsconfig/node16" "^1.0.2"
+    acorn "^8.4.1"
+    acorn-walk "^8.1.1"
+    arg "^4.1.0"
+    create-require "^1.1.0"
+    diff "^4.0.1"
+    make-error "^1.1.1"
+    v8-compile-cache-lib "^3.0.0"
+    yn "3.1.1"
+
 ts-node@^10.2.1:
   version "10.5.0"
   resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-10.5.0.tgz#618bef5854c1fbbedf5e31465cbb224a1d524ef9"
@@ -3990,16 +3998,6 @@ ts-node@^10.2.1:
     diff "^4.0.1"
     make-error "^1.1.1"
     v8-compile-cache-lib "^3.0.0"
-    yn "3.1.1"
-
-ts-node@^8:
-  version "8.10.2"
-  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-8.10.2.tgz#eee03764633b1234ddd37f8db9ec10b75ec7fb8d"
-  dependencies:
-    arg "^4.1.0"
-    diff "^4.0.1"
-    make-error "^1.1.1"
-    source-map-support "^0.5.17"
     yn "3.1.1"
 
 ts-retry-promise@^0.6.0:

--- a/yarn.lock
+++ b/yarn.lock
@@ -1131,6 +1131,16 @@ core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
 
+cosmiconfig@^8.1.3:
+  version "8.1.3"
+  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-8.1.3.tgz#0e614a118fcc2d9e5afc2f87d53cd09931015689"
+  integrity sha512-/UkO2JKI18b5jVMJUp0lvKFMpa/Gye+ZgZjKD+DGEN9y7NRcf/nK1A0sp67ONmKtnDCNMS44E6jrk0Yc3bDuUw==
+  dependencies:
+    import-fresh "^3.2.1"
+    js-yaml "^4.1.0"
+    parse-json "^5.0.0"
+    path-type "^4.0.0"
+
 cp-file@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/cp-file/-/cp-file-6.2.0.tgz#40d5ea4a1def2a9acdd07ba5c0b0246ef73dc10d"
@@ -1745,6 +1755,15 @@ fs-constants@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs-constants/-/fs-constants-1.0.0.tgz#6be0de9be998ce16af8afc24497b9ee9b7ccd9ad"
 
+fs-extra@^11.1.1:
+  version "11.1.1"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-11.1.1.tgz#da69f7c39f3b002378b0954bb6ae7efdc0876e2d"
+  integrity sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==
+  dependencies:
+    graceful-fs "^4.2.0"
+    jsonfile "^6.0.1"
+    universalify "^2.0.0"
+
 fs-extra@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-6.0.1.tgz#8abc128f7946e310135ddc93b98bddb410e7a34b"
@@ -2331,7 +2350,7 @@ js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
 
-js-yaml@4.1.0:
+js-yaml@4.1.0, js-yaml@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.0.tgz#c1fb65f8f5017901cdd2c951864ba18458a10602"
   dependencies:
@@ -2407,6 +2426,15 @@ json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.1:
 jsonfile@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-4.0.0.tgz#8771aae0799b64076b76640fca058f9c10e33ecb"
+  optionalDependencies:
+    graceful-fs "^4.1.6"
+
+jsonfile@^6.0.1:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-6.1.0.tgz#bc55b2634793c679ec6403094eb13698a6ec0aae"
+  integrity sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==
+  dependencies:
+    universalify "^2.0.0"
   optionalDependencies:
     graceful-fs "^4.1.6"
 
@@ -4108,6 +4136,11 @@ union-value@^1.0.0:
 universalify@^0.1.0, universalify@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
+
+universalify@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/universalify/-/universalify-2.0.0.tgz#75a4984efedc4b08975c5aeb73f530d02df25717"
+  integrity sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==
 
 unset-value@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Fixes https://github.com/Force-Config-Control/lightning-flow-scanner-sfdx/issues/34
- Use [cosmiconfig](https://github.com/cosmiconfig/cosmiconfig) to load configuration
- Add a **--retrieve** argument in case user wants to retrieve flows from org before scanning
- Add changelog file
- Code refactorization
  - let <=> const
  - Split main method into smaller methods
  - use fs-extra instead of sf plugin fs
  - Remove tslint (deprecated), replaced by eslint
- Add a testing GitHub action Workflow 
- Add VsCode local debugging configuration